### PR TITLE
Add Python 2.7 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,7 @@ Example
 -------
 ::
   >>> from hashprint import pformat
-  >>> from binascii import unhexlify
-  >>> print(pformat(unhexlify('CB7C8A7B567FB2C2ACC2873B04FAC2E9CC21424A')))
+  >>> print(pformat(bytearray.fromhex('CB7C8A7B567FB2C2ACC2873B04FAC2E9CC21424A')))
   +-----------------+
   |                 |
   |                 |

--- a/hashprint/__init__.py
+++ b/hashprint/__init__.py
@@ -5,7 +5,10 @@ Perform a random walk seeded by a byte array.
 Can be used to visualize SSH fingerprints.
 Inspiration: http://aarontoponce.org/drunken_bishop.pdf
 """
-from itertools import zip_longest
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 
 
 def grouper(iterable, n):


### PR DESCRIPTION
`zip_longest` is in a different location in python 2.7 and `unhexlify` produces a string instead of a `bytearray` in python 2.7 which `bin` can't call `__index__` on